### PR TITLE
c-bindings: Fix the build

### DIFF
--- a/c-bindings/PGFFFI.hs
+++ b/c-bindings/PGFFFI.hs
@@ -18,11 +18,11 @@
 module PGFFFI where
 
 import PGF
-import CString
+import Foreign.C.String
 import Foreign
 import Foreign.C.Types
 import Control.Exception
-import IO
+import System.IO
 import Data.Maybe
 -- import GF.Text.Lexing
 

--- a/c-bindings/build-gfctest.sh
+++ b/c-bindings/build-gfctest.sh
@@ -17,6 +17,6 @@
 # License along with this library; if not, see <http://www.gnu.org/licenses/>.
 src=../../src
 import=-i$src/runtime/haskell:$src/compiler
-gf --make ../../examples/tutorial/embedded/QueryEng.gf &&
+gf --make ../tutorial/embedded/QueryEng.gf &&
 ghc $import --make -fglasgow-exts -O2 -no-hs-main $* -c PGFFFI.hs &&
 ghc $import --make -fglasgow-exts -O2 -no-hs-main $* gfctest.c gf_lexing.c PGFFFI.hs -o gfctest


### PR DESCRIPTION
Fix the build of the old C bindings to the Haskell runtime. They will
probably not be used much now that there is a native C runtime, but it
was easy to get them to compile again:

build-gfctest.sh: Fix the path to QueryEng.gf to match the gf-contrib
                  repository layout. Also mark the script as executable.

PGFFFI.hs: Update the imports for the current Haskell standard.