### PR TITLE
Fix error with naming of concrete syntax

### DIFF
--- a/foods/FoodsChi.gf
+++ b/foods/FoodsChi.gf
@@ -1,4 +1,4 @@
-concrete MyFoodsChi of Foods = open Prelude in {
+concrete FoodsChi of Foods = open Prelude in {
 flags coding = utf8 ;
 lincat
     Comment, Item = Str;


### PR DESCRIPTION
Changed name of concrete syntax from "MyFoodsChi" to "FoodsChi". My
mistake for overlooking the required change.